### PR TITLE
added imgkit in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ requests-oauthlib==1.3.0
 tensorflow==2.2.0
 tensorflow-estimator==2.2.0
 urllib3==1.25.9
+imgkit==1.0.2


### PR DESCRIPTION
The imgkit module was not present in requirements.txt. I wasn't able to run bot.py due to this so I updated it.