### PR TITLE
change from request to aiohttp: isseue#7

### DIFF
--- a/Bot/bot.py
+++ b/Bot/bot.py
@@ -19,14 +19,14 @@ import discord
 import cv2
 import numpy as np
 from discord.ext import commands
-import requests
+import aiohttp
 import time
 import os
 import random
 import hashlib
 from urllib3.exceptions import InsecureRequestWarning
-import urllib
-requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+import urllib3
+urllib3.disable_warnings(category=InsecureRequestWarning)
 
 
 load_dotenv()
@@ -34,6 +34,7 @@ TOKEN = os.getenv('DISCORD_TOKEN')
 client = commands.Bot(command_prefix='!cov ')
 client.remove_command('help')
 
+session = aiohttp.ClientSession()
 
 @client.command(pass_context=True)
 async def graph(ctx, typeofgraph, arg2='none'):
@@ -376,9 +377,9 @@ async def ghelp(ctx):
 @client.command(pass_context=True)
 async def country(ctx, args, complete='false'):
     found = False
-    response = requests.get(
+    response = await session.get(
         'https://disease.sh/v3/covid-19/countries?yesterday=false&sort=cases&allowNull=true')
-    x = response.text
+    x = await response.text()
     y = sorted(json.loads(x), key=lambda x: x['country'].lower())
     country_name = None
     embedVar = discord.Embed(description="Statistics from disease.sh",
@@ -429,8 +430,8 @@ async def country(ctx, args, complete='false'):
 
 @client.command(pass_context=True)
 async def all(ctx):
-    response = requests.get('https://disease.sh/v3/covid-19/all')
-    x = response.text
+    response = await session.get('https://disease.sh/v3/covid-19/all')
+    x = await response.text()
     y = json.loads(x)
     embedVar = discord.Embed(title="Covid Worldwide Stats",
                              description="Statistics from disease.sh", color=0xe33b3b, url='https://anondoser.xyz')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ numpy==1.19.0
 opencv-python==4.3.0.36
 pandas==1.0.5
 plotly==4.8.2
-requests==2.24.0
-requests-oauthlib==1.3.0
+aiohttp==3.6.2
 tensorflow==2.2.0
 tensorflow-estimator==2.2.0
 urllib3==1.25.9
+


### PR DESCRIPTION
Changed from requests api to aiohttp and the same has been added to `requirements.txt`   
A warning is obtained due to the line: `session = aiohttp.ClientSession()` which technically has to be asynchronous.

One solution would be to:
```python
async with aiohttp.ClientSession() as session:
      """
     The bot commands
     """
```
which requires refactoring the code structure


Output after aiohttp:
![Output Screenshot](https://user-images.githubusercontent.com/48756374/88029808-1817e080-cb58-11ea-9f6f-975be3b0a309.png)



 

